### PR TITLE
Fix Java Submission Bug

### DIFF
--- a/src/app/problems/ace/ace.component.html
+++ b/src/app/problems/ace/ace.component.html
@@ -2,5 +2,5 @@
     #editor
     [(text)]="template"
     style="position: absolute; top: 0; left: 0; right: 0; bottom: 0;"
-    (change)="addNewCodeItem(template)"
+    (textChanged)="addNewCodeItem(template)"
 ></ace-editor>


### PR DESCRIPTION
## Description
- Fixes the bug with Java Submissions.
- Turns out we were using the wrong way to detect change for `ace-editor`. Taking a look at the documentation and it showed the editor being setup using `(textChanged)` instead of `(change)`. 
- Updating this ^ should fix the issue, the emitter is fired every time the text changes within the editor, including pasting with `CTRL + V` and right-clicking and pasting.
- The emitter is also fired when text is deleted, this did not happen before. 


## Types of changes
What types of changes does your code introduce?
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue
- Closes #225 

## Tests
- N/A

## Screenshots (if appropriate):
