### PR TITLE
Override tui-island_hoverable class

### DIFF
--- a/src/scss/styles.scss
+++ b/src/scss/styles.scss
@@ -1,5 +1,6 @@
 @import 'mixins';
 @import 'highlight';
+@import 'tui';
 @import '~katex/dist/katex.min.css';
 
 body {

--- a/src/scss/tui.scss
+++ b/src/scss/tui.scss
@@ -1,0 +1,10 @@
+// File used to override Taiga UI classes
+
+.tui-island_hoverable {
+    box-shadow: 0 0.05rem 0.75rem rgba(0, 0, 0, 0.025) !important;
+    border: 1px dashed var(--tui-base-03);
+
+    &:hover {
+        box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1) !important;
+    }
+}


### PR DESCRIPTION
## Description
 - Add tui scss file
 - Override .tui-island_hoverable with custom styles

## Types of changes
What types of changes does your code introduce?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue
Closes #490 

## Tests
--

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/37320754/165205665-c90c15da-cf76-4603-bb31-a032649d0bde.png)

After:
![image](https://user-images.githubusercontent.com/37320754/165205630-31cc02ce-1ede-493b-bbea-6ed96fc07d1c.png)
