### PR TITLE
Create and use sidebar component, add sidebar to question page

### DIFF
--- a/src/app/_services/api/user-actions.service.spec.ts
+++ b/src/app/_services/api/user-actions.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {UserActionsService} from './user-actions.service';
 import {TestModule} from '@test/test.module';
@@ -29,7 +29,7 @@ describe('UserActionsService', () => {
         expect(userActionsService).toBeTruthy();
     });
 
-    it('should return all actions', () => {
+    it('should return all actions', fakeAsync(() => {
         userActionsService.getUserActions().subscribe((actions) => {
             expect(actions.results).toEqual(MOCK_USER_ACTIONS);
         });
@@ -41,14 +41,16 @@ describe('UserActionsService', () => {
             previous: '',
             results: MOCK_USER_ACTIONS
         });
-    });
+        tick();
+    }));
 
-    it('should return first action', () => {
+    it('should return first action', fakeAsync(() => {
         userActionsService.getUserAction(0).subscribe((action) => {
             expect(action).toEqual(MOCK_USER_ACTIONS[0]);
         });
         const request = httpMock.expectOne(apiService.getURL('user-actions', 0));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_USER_ACTIONS[0]);
-    });
+        tick();
+    }));
 });

--- a/src/app/_services/api/user-stats.service.spec.ts
+++ b/src/app/_services/api/user-stats.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {UserStatsService} from './user-stats.service';
 import {TestModule} from '@test/test.module';
 import {ApiService} from "@app/_services/api.service";
@@ -28,12 +28,13 @@ describe('UserStatsService', () => {
         expect(userStatsService).toBeTruthy();
     });
 
-    it('should return difficultyUserStats', () => {
+    it('should return difficultyUserStats', fakeAsync(() => {
         userStatsService.getUserDifficultyStats(0).subscribe((stats) => {
             expect(stats).toEqual(MOCK_USER_DIFFICULTY_STATS);
         });
         const request = httpMock.expectOne(apiService.getURL('user-stats/difficulty', 0));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_USER_DIFFICULTY_STATS);
-    });
+        tick();
+    }));
 });

--- a/src/app/accounts/_forms/register.form.ts
+++ b/src/app/accounts/_forms/register.form.ts
@@ -15,7 +15,7 @@ export class RegisterForm {
     }
 
     static extractData(form: FormGroup): RegisterFormData {
-        return form.value;
+        return form.getRawValue();
     }
 }
 

--- a/src/app/accounts/_services/consent.service.spec.ts
+++ b/src/app/accounts/_services/consent.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {ConsentService} from './consent.service';
 import {TestModule} from '@test/test.module';
@@ -29,30 +29,33 @@ describe('ConsentService', () => {
         expect(consentService).toBeTruthy();
     });
 
-    it('submit a user consent', () => {
+    it('submit a user consent', fakeAsync(() => {
         consentService.postConsent(MOCK_ADMIN_CONSENT).subscribe((consent) => {
             expect(consent).toEqual(MOCK_ADMIN_CONSENT);
         });
         const request = httpMock.expectOne(apiService.getURL('user-consent'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_ADMIN_CONSENT);
-    });
+        tick();
+    }));
 
-    it('get user consents', () => {
+    it('get user consents', fakeAsync(() => {
         consentService.getConsent().subscribe((consents) => {
             expect(consents).toEqual([MOCK_ADMIN_CONSENT]);
         });
         const request = httpMock.expectOne(apiService.getURL('user-consent'));
         expect(request.request.method).toBe('GET');
         request.flush([MOCK_ADMIN_CONSENT]);
-    });
+        tick();
+    }));
 
-    it('remove a user consent', () => {
+    it('remove a user consent', fakeAsync(() => {
         consentService.declineConsent().subscribe((consent) => {
             expect(consent).toEqual(MOCK_ADMIN_CONSENT);
         });
         const request = httpMock.expectOne(apiService.getURL('user-consent'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_ADMIN_CONSENT);
-    });
+        tick();
+    }));
 });

--- a/src/app/accounts/profile-details/profile-details.component.spec.ts
+++ b/src/app/accounts/profile-details/profile-details.component.spec.ts
@@ -1,4 +1,4 @@
-import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {ProfileDetailsComponent} from './profile-details.component';
 import {TestModule} from '@test/test.module';
@@ -51,14 +51,15 @@ describe('ProfileDetailsComponent', () => {
         expect(component['profile'].putProfileDetails).toHaveBeenCalledWith(data, component.userDetails.id);
     });
 
-    it('should withdraw consent', () => {
+    it('should withdraw consent', fakeAsync(() => {
         spyOn(component['consentService'], 'declineConsent').and.returnValue(of(MOCK_CONSENT_DECLINE));
         component.withdraw();
         expect(component['consentService'].declineConsent).toHaveBeenCalled();
         component['consentService'].declineConsent().subscribe((declineConsent) => {
             expect(declineConsent).toEqual(MOCK_CONSENT_DECLINE);
         });
-    });
+        tick();
+    }));
 
     it('should open withdraw consent modal', () => {
         spyOn(component['dialogService'], 'open').and.callThrough();

--- a/src/app/admin/_services/category-stats.service.spec.ts
+++ b/src/app/admin/_services/category-stats.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {CategoryStatsService} from './category-stats.service';
 import {TestModule} from "@test/test.module";
@@ -29,7 +29,7 @@ describe('CategoryStatsService', () => {
         expect(service).toBeTruthy();
     });
 
-    it('should get category stats', () => {
+    it('should get category stats', fakeAsync(() => {
         service.getCategoryStats().subscribe((categoryStats) => {
             expect(categoryStats).toEqual([MOCK_NESTED_CATEGORY_2]);
             expect(categoryStats[0].children).toEqual([MOCK_NESTED_CATEGORY]);
@@ -37,5 +37,6 @@ describe('CategoryStatsService', () => {
         const request = httpMock.expectOne(apiService.getURL('admin/category-stats'));
         expect(request.request.method).toBe('GET');
         request.flush([MOCK_NESTED_CATEGORY_2]);
-    });
+        tick();
+    }));
 });

--- a/src/app/admin/_services/courses.service.spec.ts
+++ b/src/app/admin/_services/courses.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {CoursesService} from './courses.service';
 import {MOCK_VIEW_COURSE} from "@app/admin/_test/mock";
@@ -25,12 +25,13 @@ describe('ViewCoursesService', () => {
         expect(service).toBeTruthy();
     });
 
-    it('should get courses', () => {
+    it('should get courses', fakeAsync(() => {
         service.getCourses().subscribe((courses) => {
             expect(courses).toEqual([MOCK_VIEW_COURSE]);
         });
         const request = httpMock.expectOne(apiService.getURL('admin/courses'));
         expect(request.request.method).toBe('GET');
         request.flush([MOCK_VIEW_COURSE]);
-    });
+        tick();
+    }));
 });

--- a/src/app/admin/_services/question-count.service.spec.ts
+++ b/src/app/admin/_services/question-count.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {QuestionCountService} from './question-count.service';
 import {TestModule} from "@test/test.module";
@@ -29,12 +29,13 @@ describe('QuestionCountService', () => {
         expect(service).toBeTruthy();
     });
 
-    it('should get question counts', () => {
+    it('should get question counts', fakeAsync(() => {
         service.getQuestionCount().subscribe((questionCounts) => {
             expect(questionCounts).toEqual([MOCK_QUESTION_COUNT]);
         });
         const request = httpMock.expectOne(apiService.getURL('admin/question-count'));
         expect(request.request.method).toBe('GET');
         request.flush([MOCK_QUESTION_COUNT]);
-    });
+        tick();
+    }));
 });

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -16,6 +16,7 @@ import {TuiButtonModule, TuiLoaderModule, TuiScrollbarModule, TuiTextfieldContro
 import {TuiRingChartModule} from '@taiga-ui/addon-charts';
 import {TuiFilterPipeModule} from '@taiga-ui/cdk';
 import {CoursesComponent} from './courses/courses.component';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 
 @NgModule({
@@ -28,6 +29,7 @@ import {CoursesComponent} from './courses/courses.component';
     imports: [
         CommonModule,
         FormsModule,
+        SidebarModule,
         TuiButtonModule,
         TuiDataListWrapperModule,
         TuiFilterPipeModule,

--- a/src/app/admin/courses/courses.component.html
+++ b/src/app/admin/courses/courses.component.html
@@ -1,4 +1,4 @@
-<aside class="courses tui-container tui-container_fullwidth">
+<app-sidebar sidebarId="adminSidebar" position="right" size="l">
     <h2 class="tui-text_h6 tui-space_bottom-4 tui-space_top-6">Courses</h2>
     <tui-loader [overlay]="true" [showLoader]="!courseData">
         <div class="courses-islands tui-space_bottom-6">
@@ -16,4 +16,4 @@
             </tui-island>
         </div>
     </tui-loader>
-</aside>
+</app-sidebar>

--- a/src/app/admin/courses/courses.component.scss
+++ b/src/app/admin/courses/courses.component.scss
@@ -1,13 +1,6 @@
 @import "mixins";
 
 .courses {
-    @include sidebar(right, 20rem);
-    justify-content: unset;
-
-    @include screen-sm() {
-        margin-top: var(--tui-padding-l);
-    }
-
     &-islands {
         display: flex;
         flex-direction: column;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,14 +1,29 @@
-import {TestBed, waitForAsync} from '@angular/core/testing';
+import {fakeAsync, flush, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {AppComponent} from './app.component';
 import {TestModule} from '@test/test.module';
+import {RouterTestingModule} from '@angular/router/testing';
+import {HomepageComponent} from '@app/components/homepage/homepage.component';
+import {LandingPageComponent} from '@app/components/landing-page/landing-page.component';
+import {AccountsModule} from '@app/accounts/accounts.module';
+
 
 describe('AppComponent', () => {
     let app: AppComponent;
 
     beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
+            declarations: [AppComponent, LandingPageComponent, HomepageComponent],
             imports: [
-                TestModule
+                TestModule,
+                AccountsModule,
+                RouterTestingModule.withRoutes([{
+                    path: '',
+                    pathMatch: 'full',
+                    component: LandingPageComponent,
+                }, {
+                    path: 'homepage',
+                    component: HomepageComponent,
+                }], {relativeLinkResolution: 'legacy'})
             ]
         }).compileComponents();
     }));
@@ -16,19 +31,24 @@ describe('AppComponent', () => {
     beforeEach(() => {
         const fixture = TestBed.createComponent(AppComponent);
         app = fixture.componentInstance;
+        app['router'].initialNavigation();
     });
 
     it('should create the app', () => {
         expect(app).toBeTruthy();
     });
 
-    it('should hide footer on landing page', () => {
-        app['router'].navigate(['/']).then().catch();
+    it('should hide footer on landing page', fakeAsync(() => {
+        app['router'].navigate(['/']);
+        tick();
         expect(app.hideFooterForLanding).toBeTrue();
-    });
+        flush();
+    }));
 
-    it('should show footer on homepage', () => {
-        app['router'].navigate(['/homepage']).then().catch();
+    it('should show footer on homepage', fakeAsync(() => {
+        app['router'].navigate(['/homepage']);
+        tick();
         expect(app.hideFooterForLanding).toBeFalse();
-    });
+        flush();
+    }));
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -65,6 +65,7 @@ import {ContactModule} from '@app/components/contact/contact.module';
 import {CodeEditorModule} from '@app/components/code-editor/code-editor.module';
 import {FooterModule} from '@app/components/footer/footer.module';
 import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 @NgModule({
     declarations: [
@@ -105,6 +106,7 @@ import {NgDompurifySanitizer} from '@tinkoff/ng-dompurify';
         ReactiveFormsModule,
         RecaptchaFormsModule,
         RecaptchaModule,
+        SidebarModule,
         TuiActiveZoneModule,
         TuiAvatarModule,
         TuiButtonModule,

--- a/src/app/components/homepage/homepage.component.html
+++ b/src/app/components/homepage/homepage.component.html
@@ -6,8 +6,8 @@
             <app-inactive-courses></app-inactive-courses>
         </div>
     </div>
-    <aside class="homepage_sidebar tui-container tui-container_fullwidth">
+    <app-sidebar sidebarId="homepageSidebar" position="right">
         <app-recent-viewed-questions></app-recent-viewed-questions>
         <app-recent-user-actions></app-recent-user-actions>
-    </aside>
+    </app-sidebar>
 </div>

--- a/src/app/components/homepage/homepage.component.scss
+++ b/src/app/components/homepage/homepage.component.scss
@@ -10,13 +10,4 @@
     &_content {
         flex: 1;
     }
-
-    &_sidebar {
-        @include sidebar(right);
-        justify-content: unset;
-
-        @include screen-sm() {
-            margin-top: var(--tui-padding-l);
-        }
-    }
 }

--- a/src/app/components/homepage/homepage.component.spec.ts
+++ b/src/app/components/homepage/homepage.component.spec.ts
@@ -1,7 +1,8 @@
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {HomepageComponent} from './homepage.component';
-import {TestModule} from '../../../test/test.module';
+import {TestModule} from '@test/test.module';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 describe('HomepageComponent', () => {
     let component: HomepageComponent;
@@ -9,7 +10,7 @@ describe('HomepageComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [TestModule]
+            imports: [TestModule, SidebarModule]
         }).compileComponents();
     });
 

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -1,0 +1,49 @@
+<aside
+    [class.sidebar_left]="position === 'left'"
+    [class.sidebar_right]="position === 'right'"
+    [class.sidebar_small]="size === 's'"
+    [class.sidebar_large]="size === 'l'"
+    [class.sidebar-closed]="!sidebarOpen"
+>
+    <div
+        class="sidebar-content tui-container tui-container_fullwidth"
+        [class.sidebar-content_between]="spacing === 'between'"
+        [class.sidebar-content_closed]="!sidebarOpen"
+    >
+        <ng-content></ng-content>
+    </div>
+    <div
+        class="sidebar-toggle"
+        [class.sidebar-toggle_closed]="!sidebarOpen"
+        [class.sidebar-toggle_left]="position === 'left'"
+        *ngIf="toggleable"
+    >
+        <button
+            tuiIconButton
+            appearance="flat"
+            shape="rounded"
+            class="sidebar-toggle_button tui-space_vertical-3"
+            [class.tui-space_horizontal-6]="sidebarOpen"
+            size="s"
+            (click)="toggleSidebar()"
+            tuiDescribedBy="sidebar-{{sidebarId}}"
+            tuiHintId="sidebar-{{sidebarId}}"
+            tuiHintMode="onDark"
+            [tuiHint]="toggleTooltip"
+        >
+            <tui-svg
+                class="sidebar-toggle_icon"
+                [class.sidebar-toggle_icon-closed]="!sidebarOpen"
+                [src]="position === 'left' ? 'tuiIconChevronLeft' : 'tuiIconChevronRight'"
+            ></tui-svg>
+        </button>
+        <ng-template #toggleTooltip>
+            <ng-container *ngIf="sidebarOpen else closedSidebar">
+                Hide Sidebar
+            </ng-container>
+            <ng-template #closedSidebar>
+                Show Sidebar
+            </ng-template>
+        </ng-template>
+    </div>
+</aside>

--- a/src/app/components/sidebar/sidebar.component.scss
+++ b/src/app/components/sidebar/sidebar.component.scss
@@ -1,0 +1,91 @@
+@import "mixins";
+@import '~@taiga-ui/core/styles/taiga-ui-local';
+
+.sidebar {
+    &_left {
+        @include sidebar(left);
+    }
+
+    &_right{
+        @include sidebar(right);
+    }
+
+    &_small {
+        width: 15rem;
+
+        @include screen-sm() {
+            width: auto;
+        }
+    }
+
+    &_large {
+        width: 22rem;
+
+        @include screen-sm() {
+            width: auto;
+        }
+    }
+
+    &-closed {
+        width: 4rem;
+
+        @include screen-sm() {
+            width: auto;
+        }
+    }
+
+    &-content {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+
+        &_between {
+            justify-content: space-between;
+            height: 100%;
+        }
+
+        &_closed {
+            display: none;
+
+            @include screen-sm() {
+                display: unset;
+            }
+        }
+    }
+
+    &-toggle {
+        position: sticky;
+        bottom: 0;
+        left: 0;
+        margin-top: auto;
+        border-top: 1px solid var(--tui-base-03);
+        background-color: var(--tui-base-01);
+        display: flex;
+
+        @include screen-sm() {
+            display: none;
+        }
+
+        &_left {
+            justify-content: flex-end;
+        }
+
+        &_closed {
+            justify-content: center;
+            align-items: center;
+        }
+
+        &_button {
+            border: 1px solid var(--tui-base-03);
+        }
+
+        &_icon {
+            color: var(--tui-text-01);
+            @include transition(transform);
+
+            &-closed {
+                transform: rotate(180deg);
+            }
+        }
+    }
+}

--- a/src/app/components/sidebar/sidebar.component.spec.ts
+++ b/src/app/components/sidebar/sidebar.component.spec.ts
@@ -1,0 +1,55 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {SidebarComponent} from './sidebar.component';
+import {TestModule} from '@test/test.module';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
+
+describe('SidebarComponent', () => {
+    let component: SidebarComponent;
+    let fixture: ComponentFixture<SidebarComponent>;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({
+            declarations: [SidebarComponent],
+            imports: [TestModule, SidebarModule]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(SidebarComponent);
+        component = fixture.componentInstance;
+        component.sidebarId = 'test-id';
+        localStorage.removeItem(component.storageKey);
+        spyOn(component, 'getSidebarDirectory').and.callThrough();
+        fixture.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should throw error when no ID is provided', () => {
+        component.sidebarId = undefined;
+        fixture.detectChanges();
+        expect(component.getSidebarDirectory).toThrowError('Attach an ID to the sidebar!');
+    });
+
+    it('should not throw error when not toggleable', () => {
+        component.sidebarId = undefined;
+        component.toggleable = false;
+        fixture.detectChanges();
+        expect(component.getSidebarDirectory).toThrowError('Attach an ID to the sidebar!');
+    });
+
+    it('should initialize with empty directory', () => {
+        expect(component.getSidebarDirectory).toHaveBeenCalled();
+        expect(localStorage.getItem(component.storageKey)).toEqual('{}');
+    });
+
+    it('should toggle sidebar and save to storage', () => {
+        const sidebarOpen = component.sidebarOpen;
+        component.toggleSidebar();
+        expect(component.sidebarOpen).toEqual(!sidebarOpen);
+        expect(localStorage.getItem(component.storageKey)).toEqual(`{"${component.sidebarId}":${!sidebarOpen}}`);
+    });
+});

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -1,0 +1,55 @@
+import {Component, Input, OnInit} from '@angular/core';
+
+@Component({
+    selector: 'app-sidebar',
+    templateUrl: './sidebar.component.html',
+    styleUrls: ['./sidebar.component.scss']
+})
+export class SidebarComponent implements OnInit{
+
+    readonly storageKey = 'rememberSidebarOpen';
+
+    @Input() sidebarId: string;
+    @Input() position: 'left' | 'right' = 'left';
+    @Input() size: 's' | 'm' | 'l' = 'm';
+    @Input() spacing: 'start' | 'between' = 'start';
+    @Input() toggleable = true;
+    sidebarOpen = true;
+
+    ngOnInit() {
+        if (!this.toggleable) return;
+
+        const directory = this.getSidebarDirectory();
+        if (!directory) return;
+        this.sidebarOpen = directory[this.sidebarId] ?? true;
+    }
+
+    /**
+     * Get the sidebar directory from local storage.
+     * Create new empty directory if none is found.
+     * @throws Error when no sidebar ID is provided.
+     */
+    getSidebarDirectory(): object | undefined {
+        if (!this.sidebarId) throw new Error('Attach an ID to the sidebar!');
+
+        const sidebarDirectoryString = localStorage.getItem(this.storageKey);
+        if (!sidebarDirectoryString) {
+            localStorage.setItem(this.storageKey, JSON.stringify({}));
+            return {};
+        }
+        return JSON.parse(sidebarDirectoryString);
+    }
+
+    /**
+     * Open and close the sidebar, saving state to local storage.
+     * If directory is not found, nothing is saved.
+     */
+    toggleSidebar(): void {
+        this.sidebarOpen = !this.sidebarOpen;
+
+        const directory = this.getSidebarDirectory();
+        if (!directory) return;
+        directory[this.sidebarId] = this.sidebarOpen;
+        localStorage.setItem(this.storageKey, JSON.stringify(directory));
+    }
+}

--- a/src/app/components/sidebar/sidebar.module.ts
+++ b/src/app/components/sidebar/sidebar.module.ts
@@ -1,0 +1,23 @@
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {SidebarComponent} from './sidebar.component';
+import {TuiButtonModule, TuiDescribedByModule, TuiHintModule, TuiSvgModule} from '@taiga-ui/core';
+
+
+@NgModule({
+    declarations: [
+        SidebarComponent
+    ],
+    exports: [
+        SidebarComponent
+    ],
+    imports: [
+        CommonModule,
+        TuiButtonModule,
+        TuiDescribedByModule,
+        TuiHintModule,
+        TuiSvgModule
+    ]
+})
+export class SidebarModule {
+}

--- a/src/app/course/_services/course-event.service.spec.ts
+++ b/src/app/course/_services/course-event.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {CourseEventService} from './course-event.service';
 import {TestModule} from '@test/test.module';
@@ -30,66 +30,73 @@ describe('CourseEventService', () => {
         expect(courseEventService).toBeTruthy();
     });
 
-    it('getCourseEvent should return a single courseEvent', () => {
+    it('getCourseEvent should return a single courseEvent', fakeAsync(() => {
         courseEventService.getCourseEvent(0).subscribe((courseEvent) => {
             expect(courseEvent).toEqual(MOCK_COURSE_EVENT);
         });
         const request = httpMock.expectOne(apiService.getURL('event', 0));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_COURSE_EVENT);
-    });
+        tick();
+    }));
 
-    it('deleteCourseEvent deletes a course event', () => {
+    it('deleteCourseEvent deletes a course event', fakeAsync(() => {
         courseEventService.deleteCourseEvent(0).subscribe((response) => {
             expect(response).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('event', 0));
         expect(request.request.method).toBe('DELETE');
         request.flush('Course Event Deleted');
-    });
+        tick();
+    }));
 
-    it('addCourseEvent should add a new Course Event', () => {
+    it('addCourseEvent should add a new Course Event', fakeAsync(() => {
         courseEventService.addCourseEvent(MOCK_COURSE_EVENT).subscribe((response) => {
             expect(response).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('event'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_COURSE_EVENT);
-    });
+        tick();
+    }));
 
-    it('updateCourseEvent should update a new Course Event', () => {
+    it('updateCourseEvent should update a new Course Event', fakeAsync(() => {
         courseEventService.updateCourseEvent(MOCK_COURSE_EVENT).subscribe((response) => {
             expect(response).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('event', MOCK_COURSE_EVENT.id));
         expect(request.request.method).toBe('PUT');
         request.flush(MOCK_COURSE_EVENT);
-    });
+        tick();
+    }));
 
-    it('getEventTypes', () => {
+    it('getEventTypes', fakeAsync(() => {
         courseEventService.getEventTypes().subscribe((eventTypes) => {
             expect(eventTypes).toEqual(MOCK_EVENT_TYPES);
         });
         const request = httpMock.expectOne(apiService.getURL('event', 'get-event-types'));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_EVENT_TYPES);
-    });
+        tick();
+    }));
 
-    it('getAllEvents', () => {
+    it('getAllEvents', fakeAsync(() => {
         courseEventService.getAllEvents().subscribe((events) => {
             expect(events).toEqual([MOCK_COURSE_EVENT]);
         });
         const request = httpMock.expectOne(apiService.getURL('event'));
         expect(request.request.method).toBe('GET');
         request.flush([MOCK_COURSE_EVENT]);
-    });
+        tick();
+    }));
 
-    it('import a courseEvent by clicking the import button', () => {
+    it('import a courseEvent by clicking the import button', fakeAsync(() => {
         courseEventService.importCourseEvent(MOCK_COURSE_EVENT, MOCK_COURSE1.id).subscribe((response) => {
             expect(response.status).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('event', 'import-event'));
         expect(request.request.method).toBe('POST');
         request.flush(new HttpResponse());
-    });
+        tick();
+    }));
 });

--- a/src/app/course/_services/course.service.spec.ts
+++ b/src/app/course/_services/course.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {CourseService} from './course.service';
 import {TestModule} from '@test/test.module';
@@ -37,111 +37,123 @@ describe('CourseService', () => {
         expect(courseService).toBeTruthy();
     });
 
-    it('getCourseEvent should return a single courseEvent', () => {
+    it('getCourseEvent should return a single courseEvent', fakeAsync(() => {
         courseService.getUserStats(0, 1).subscribe((userStats) => {
             expect(userStats).toEqual(MOCK_USER_STATS);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'user-stats', 1));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_USER_STATS);
-    });
+        tick();
+    }));
 
-    it('getCourseRegistrationStatus', () => {
+    it('getCourseRegistrationStatus', fakeAsync(() => {
         courseService.getCourseRegistrationStatus(0).subscribe((response) => {
             expect(response).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'get-registration-status'));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_REGISTRATION_STATUS);
-    });
+        tick();
+    }));
 
-    it('validateEvent should return truthy value', () => {
+    it('validateEvent should return truthy value', fakeAsync(() => {
         courseService.validateEvent(0, 1).subscribe((response) => {
             expect(response).toBeTruthy();
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'validate-event', 1));
         expect(request.request.method).toBe('GET');
         request.flush({success: true});
-    });
+        tick();
+    }));
 
-    it('getCourses', () => {
+    it('getCourses', fakeAsync(() => {
         courseService.getCourses().subscribe((response) => {
             expect(response).toEqual(MOCK_COURSES);
         });
         const request = httpMock.expectOne('http://localhost:8000/api/course/?registered=false&page=1&page_size=50&ordering=');
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_COURSES);
-    });
+        tick();
+    }));
 
-    it('getCourse should work', () => {
+    it('getCourse should work', fakeAsync(() => {
         courseService.getCourse(0).subscribe((response) => {
             expect(response).toEqual(MOCK_COURSE1);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_COURSE1);
-    });
+        tick();
+    }));
 
-    it('register method should work for single student', () => {
+    it('register method should work for single student', fakeAsync(() => {
         courseService.register(0, MOCK_IDENTIFICATION_STEP1).subscribe((response) => {
             expect(response).toEqual(MOCK_IDENTIFICATION_RESPONSE1);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'register'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_IDENTIFICATION_RESPONSE1);
-    });
+        tick();
+    }));
 
-    it('register method should work for single student when confirming name', () => {
+    it('register method should work for single student when confirming name', fakeAsync(() => {
         courseService.register(0, MOCK_CONFIRM_STEP1).subscribe((response) => {
             expect(response).toEqual(MOCK_CONFIRM_RESPONSE1);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'register'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_CONFIRM_RESPONSE1);
-    });
+        tick();
+    }));
 
-    it('register method should work for multiple students with same name', () => {
+    it('register method should work for multiple students with same name', fakeAsync(() => {
         courseService.register(0, MOCK_IDENTIFICATION_STEP2).subscribe((response) => {
             expect(response).toEqual(MOCK_IDENTIFICATION_RESPONSE2);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'register'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_IDENTIFICATION_RESPONSE2);
-    });
+        tick();
+    }));
 
-    it('register method should work for single student when confirming with correct student number', () => {
+    it('register method should work for single student when confirming with correct student number', fakeAsync(() => {
         courseService.register(0, MOCK_CONFIRM_STEP2_SUCCESS).subscribe((response) => {
             expect(response).toEqual(MOCK_CONFIRM_RESPONSE2_SUCCESS);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'register'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_CONFIRM_RESPONSE2_SUCCESS);
-    });
+        tick();
+    }));
 
-    it('register method should work for single student when confirming with incorrect student number', () => {
+    it('register method should work for single student when confirming with incorrect student number', fakeAsync(() => {
         courseService.register(0, MOCK_CONFIRM_STEP2_FAIL).subscribe((response) => {
             expect(response).toEqual(MOCK_CONFIRM_RESPONSE2_FAIL);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'register'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_CONFIRM_RESPONSE2_FAIL);
-    });
+        tick();
+    }));
 
-    it('verify method should work for single student with correct code', () => {
+    it('verify method should work for single student with correct code', fakeAsync(() => {
         courseService.registerVerify(0, MOCK_VERIFY_STEP1).subscribe((response) => {
             expect(response).toEqual(MOCK_VERIFY_SUCCESS);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'verify'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_VERIFY_SUCCESS);
-    });
+        tick();
+    }));
 
-    it('verify method should work for single student with incorrect code', () => {
+    it('verify method should work for single student with incorrect code', fakeAsync(() => {
         courseService.registerVerify(0, MOCK_VERIFY_STEP1_FAIL).subscribe((response) => {
             expect(response).toEqual(MOCK_VERIFY_FAIL);
         });
         const request = httpMock.expectOne(apiService.getURL('course', 0, 'verify'));
         expect(request.request.method).toBe('POST');
         request.flush(MOCK_VERIFY_FAIL);
-    });
+        tick();
+    }));
 });

--- a/src/app/course/_services/token-use.service.spec.ts
+++ b/src/app/course/_services/token-use.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {TokenUseService} from './token-use.service';
 import {TestModule} from '@test/test.module';
 import {ApiService} from "@app/_services/api.service";
@@ -28,7 +28,7 @@ describe('TokenUseService', () => {
         expect(tokenUseService).toBeTruthy();
     });
 
-    it('useTokens', () => {
+    it('useTokens', fakeAsync(() => {
         const data = {};
         MOCK_COURSE_REGISTRATION.token_uses.forEach(tokenUse => data[tokenUse.option.id] = tokenUse.num_used);
         tokenUseService.useTokens(data, MOCK_COURSE_REGISTRATION.id).subscribe((response) => {
@@ -37,5 +37,6 @@ describe('TokenUseService', () => {
         const request = httpMock.expectOne(apiService.getURL('token-use', 'use', MOCK_COURSE_REGISTRATION.id));
         expect(request.request.method).toBe('POST');
         request.flush({success: true});
-    });
+        tick();
+    }));
 });

--- a/src/app/course/_test/course-registration/course-registration-stepper/course-registration-stepper.component.spec.ts
+++ b/src/app/course/_test/course-registration/course-registration-stepper/course-registration-stepper.component.spec.ts
@@ -43,7 +43,7 @@ describe('CourseRegistrationStepperComponent', () => {
     });
 
     it('should set next step', () => {
-        spyOn(component, 'setStepComplete');
+        spyOn(component, 'setStepComplete').and.callThrough();
         expect(component.currentStep).toEqual(0);
         component.setNextStep();
         expect(component.currentStep).toEqual(1);

--- a/src/app/course/course.module.ts
+++ b/src/app/course/course.module.ts
@@ -24,7 +24,7 @@ import {
     TuiInputDateRangeModule,
     TuiInputModule,
     TuiInputTimeModule,
-    TuiIslandModule, 
+    TuiIslandModule,
     TuiMarkerIconModule,
     TuiSelectModule,
     TuiStepperModule,
@@ -60,6 +60,7 @@ import {PipesModule} from '@app/_helpers/pipes/pipes.module';
 import {PracticeProblemComponent} from './practice-problem/practice-problem.component';
 import {ProblemsModule} from '@app/problems/problems.module';
 import {TuiSidebarModule} from '@taiga-ui/addon-mobile';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 @NgModule({
     declarations: [
@@ -85,6 +86,7 @@ import {TuiSidebarModule} from '@taiga-ui/addon-mobile';
         PipesModule,
         ProblemsModule,
         ReactiveFormsModule,
+        SidebarModule,
         TextMaskModule,
         TuiActiveZoneModule,
         TuiAvatarModule,

--- a/src/app/course/practice-problem/practice-problem.component.html
+++ b/src/app/course/practice-problem/practice-problem.component.html
@@ -1,5 +1,5 @@
 <div class="practice">
-    <aside class="practice-sidebar tui-container tui-container_fullwidth">
+    <app-sidebar sidebarId="practiceSidebar" position="left" spacing="between">
         <div class="practice-sidebar_content tui-space_top-6">
             <div
                 class="practice-sidebar_content-breadcrumbs tui-space_bottom-2"
@@ -118,7 +118,7 @@
                 Next Question
             </button>
         </div>
-    </aside>
+    </app-sidebar>
     <div class="practice-content">
         <app-problem-view
             *ngIf="currentQuestionId && category && uqjs else noProblems"

--- a/src/app/course/practice-problem/practice-problem.component.scss
+++ b/src/app/course/practice-problem/practice-problem.component.scss
@@ -9,8 +9,6 @@
     }
 
     &-sidebar {
-        @include sidebar(left);
-
         &_content {
             display: flex;
             flex-direction: column;

--- a/src/app/course/practice-problem/practice-problem.component.scss
+++ b/src/app/course/practice-problem/practice-problem.component.scss
@@ -59,10 +59,6 @@
     &-content {
         width: 100%;
 
-        @include screen-sm() {
-            margin-top: 4rem;
-        }
-
         &_none {
             display: flex;
             flex-direction: column;

--- a/src/app/course/practice-problem/practice-problem.component.spec.ts
+++ b/src/app/course/practice-problem/practice-problem.component.spec.ts
@@ -31,6 +31,7 @@ import {ProblemViewComponent} from '@app/problems/problem-view/problem-view.comp
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {StringifyTuiDataListPipe} from '@app/_helpers/pipes/stringify-tui-data-list.pipe';
 import {of} from 'rxjs';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 
 describe('PracticeProblemComponent', () => {
@@ -72,7 +73,8 @@ describe('PracticeProblemComponent', () => {
                 TuiHostedDropdownModule,
                 TuiTextfieldControllerModule,
                 TuiCheckboxLabeledModule,
-                TuiMarkerIconModule
+                TuiMarkerIconModule,
+                SidebarModule
             ]
         }).compileComponents();
     });

--- a/src/app/problems/_services/difficulty.service.spec.ts
+++ b/src/app/problems/_services/difficulty.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {DifficultyService} from './difficulty.service';
 import {TestModule} from '@test/test.module';
@@ -28,7 +28,7 @@ describe('DifficultyService', () => {
         expect(difficultyService).toBeTruthy();
     });
 
-    it('getDifficulties returns difficulties', () => {
+    it('getDifficulties returns difficulties', fakeAsync(() => {
         difficultyService.getDifficulties().subscribe((difficulties) => {
             expect(difficulties.length).toEqual(MOCK_DIFFICULTIES.length);
             expect(difficulties).toEqual(MOCK_DIFFICULTIES);
@@ -36,5 +36,6 @@ describe('DifficultyService', () => {
         const request = httpMock.expectOne(apiService.getURL('difficulty'));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_DIFFICULTIES);
-    });
+        tick();
+    }));
 });

--- a/src/app/problems/_services/question.service.spec.ts
+++ b/src/app/problems/_services/question.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {QuestionService} from './question.service';
 import {TestModule} from '@test/test.module';
@@ -34,7 +34,7 @@ describe('QuestionService', () => {
         expect(questionService).toBeTruthy();
     });
 
-    it('getQuestions returns all questions', () => {
+    it('getQuestions returns all questions', fakeAsync(() => {
         questionService.getQuestions().subscribe((questions) => {
             expect(questions.results.length).toEqual(MOCK_QUESTIONS.length);
             expect(questions.results).toEqual(MOCK_QUESTIONS);
@@ -44,81 +44,90 @@ describe('QuestionService', () => {
         request.flush({
             results: MOCK_QUESTIONS
         });
-    });
+        tick();
+    }));
 
-    it('getQuestion returns a single question', () => {
+    it('getQuestion returns a single question', fakeAsync(() => {
         questionService.getQuestion(MOCK_QUESTIONS[0].id).subscribe((question) => {
             expect(question).toEqual(MOCK_QUESTIONS[0]);
         });
         const request = httpMock.expectOne(apiService.getURL('questions', MOCK_QUESTIONS[0].id));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_QUESTIONS[0]);
-    });
+        tick();
+    }));
 
     it('getQuestionType returns the question type', () => {
         expect(questionService.getQuestionType(MOCK_QUESTIONS[0])).toEqual('multiple choice question');
     });
 
-    it('deleteQuestion deletes a question', () => {
+    it('deleteQuestion deletes a question', fakeAsync(() => {
         questionService.deleteQuestion(0).subscribe((response) => {
             expect(response.status).toEqual(200);
         });
         const request = httpMock.expectOne(apiService.getURL('questions', 0));
         expect(request.request.method).toBe('DELETE');
         request.flush({}, {status: 200, statusText: 'Ok'});
-    });
+        tick();
+    }));
 
-    it('putMultipleChoiceQuestion', () => {
+    it('putMultipleChoiceQuestion', fakeAsync(() => {
         questionService.putMultipleChoiceQuestion(MOCK_MCQ_FORM_DATA, 0).subscribe((response) => {
             expect(response.status).toEqual(200);
         });
         const request = httpMock.expectOne(apiService.getURL('multiple-choice-question', 0));
         expect(request.request.method).toBe('PUT');
         request.flush({}, {status: 200, statusText: 'Ok'});
-    });
+        tick();
+    }));
 
-    it('putJavaQuestion', () => {
+    it('putJavaQuestion', fakeAsync(() => {
         questionService.putJavaQuestion(MOCK_JAVA_FORM_DATA, 0).subscribe((response) => {
             expect(response.status).toEqual(200);
         });
         const request = httpMock.expectOne(apiService.getURL('java-question', 0));
         expect(request.request.method).toBe('PUT');
         request.flush({}, {status: 200, statusText: 'Ok'});
-    });
+        tick();
+    }));
 
-    it('putParsonsQuestion', () => {
+    it('putParsonsQuestion', fakeAsync(() => {
         questionService.putParsonsQuestion(MOCK_PARSONS_FORM_DATA, 0).subscribe((response) => {
             expect(response.status).toEqual(200);
         });
         const request = httpMock.expectOne(apiService.getURL('parsons-question', 0));
         expect(request.request.method).toBe('PUT');
         request.flush({}, {status: 200, statusText: 'Ok'});
-    });
+        tick();
+    }));
 
-    it('postMultipleChoiceQuestion', () => {
+    it('postMultipleChoiceQuestion', fakeAsync(() => {
         questionService.postMultipleChoiceQuestion(MOCK_MCQ_FORM_DATA).subscribe((response) => {
             expect(response.status).toEqual(201);
         });
         const request = httpMock.expectOne(apiService.getURL('multiple-choice-question'));
         expect(request.request.method).toBe('POST');
         request.flush({}, {status: 201, statusText: 'Created'});
-    });
+        tick();
+    }));
 
-    it('postJavaQuestion', () => {
+    it('postJavaQuestion', fakeAsync(() => {
         questionService.postJavaQuestion(MOCK_JAVA_FORM_DATA).subscribe((response) => {
             expect(response.status).toEqual(201);
         });
         const request = httpMock.expectOne(apiService.getURL('java-question'));
         expect(request.request.method).toBe('POST');
         request.flush({}, {status: 201, statusText: 'Created'});
-    });
+        tick();
+    }));
 
-    it('postParsonsQuestion', () => {
+    it('postParsonsQuestion', fakeAsync(() => {
         questionService.postParsonsQuestion(MOCK_PARSONS_FORM_DATA).subscribe((response) => {
             expect(response.status).toEqual(201);
         });
         const request = httpMock.expectOne(apiService.getURL('parsons-question'));
         expect(request.request.method).toBe('POST');
         request.flush({}, {status: 201, statusText: 'Created'});
-    });
+        tick();
+    }));
 });

--- a/src/app/problems/_services/submission.service.spec.ts
+++ b/src/app/problems/_services/submission.service.spec.ts
@@ -1,4 +1,4 @@
-import {TestBed} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 
 import {SubmissionService} from './submission.service';
 import {TestModule} from '@test/test.module';
@@ -29,16 +29,17 @@ describe('SubmissionService', () => {
         expect(submissionService).toBeTruthy();
     });
 
-    it('getSubmission returns a submission', () => {
+    it('getSubmission returns a submission', fakeAsync(() => {
         submissionService.getSubmission(MOCK_SUBMISSIONS[1].pk).subscribe((submission) => {
             expect(submission).toEqual(MOCK_SUBMISSIONS[1]);
         });
         const request = httpMock.expectOne(apiService.getURL('submission', MOCK_SUBMISSIONS[1].pk));
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_SUBMISSIONS.find(submission => submission.pk === MOCK_SUBMISSIONS[1].pk));
-    });
+        tick();
+    }));
 
-    it('getPreviousSubmissions returns submissions for a question', () => {
+    it('getPreviousSubmissions returns submissions for a question', fakeAsync(() => {
         submissionService.getPreviousSubmissions(MOCK_QUESTIONS[0].id).subscribe((submissions) => {
             expect(submissions.length).toEqual(MOCK_SUBMISSIONS.filter(submission => submission.question.id === MOCK_QUESTIONS[0].id).length);
             expect(submissions[0]).toEqual(MOCK_SUBMISSIONS[0]);
@@ -46,14 +47,16 @@ describe('SubmissionService', () => {
         const request = httpMock.expectOne('http://localhost:8000/api/submission/?question=0&ordering=%5Bobject%20Object%5D');
         expect(request.request.method).toBe('GET');
         request.flush(MOCK_SUBMISSIONS.filter(submission => submission.question.id === MOCK_QUESTIONS[0].id));
-    });
+        tick();
+    }));
 
-    it('postQuestionSubmission makes request successfully', () => {
+    it('postQuestionSubmission makes request successfully', fakeAsync(() => {
         submissionService.postQuestionSubmission({question: 0, solution: ''}).subscribe((response) => {
             expect(response.status).toEqual(200);
         });
         const request = httpMock.expectOne(apiService.getURL('submission', 'submit'));
         expect(request.request.method).toBe('POST');
         request.flush({status: 200});
-    });
+        tick();
+    }));
 });

--- a/src/app/problems/_test/problem-view/problem-view.component.spec.ts
+++ b/src/app/problems/_test/problem-view/problem-view.component.spec.ts
@@ -9,6 +9,7 @@ import {UqjServiceMock} from "@app/problems/_test/_services/uqj.service.mock";
 import {ActivatedRoute} from "@angular/router";
 import {MOCK_QUESTION_SUBMISSION, MOCK_SUBMISSIONS, MOCK_UQJ, MOCK_UQJS} from "@app/problems/_test/mock";
 import {TitleCasePipe} from "@angular/common";
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 describe('ProblemViewComponent', () => {
     let component: ProblemViewComponent;
@@ -16,7 +17,7 @@ describe('ProblemViewComponent', () => {
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            imports: [TestModule],
+            imports: [TestModule, SidebarModule],
             declarations: [ProblemViewComponent, TitleCasePipe],
             providers: [
                 {provide: SubmissionService, useClass: SubmissionServiceMock},

--- a/src/app/problems/problem-set/problem-set.component.ts
+++ b/src/app/problems/problem-set/problem-set.component.ts
@@ -98,8 +98,8 @@ export class ProblemSetComponent implements OnInit, AfterContentChecked {
             this.difficulties = difficulties;
         });
         this.form['parentCategory'].valueChanges.subscribe((value) => {
-            const parentCategoryPK = this.categories.filter(c => c.name === value)[0].pk;
-            this.subCategories = this.categories.filter(c => c.parent === parentCategoryPK);
+            const parentCategoryPK = this.categories?.filter(c => c.name === value)[0].pk;
+            this.subCategories = this.categories?.filter(c => c.parent === parentCategoryPK);
         });
     }
 

--- a/src/app/problems/problem-view/problem-view.component.html
+++ b/src/app/problems/problem-view/problem-view.component.html
@@ -1,50 +1,50 @@
-<div class="tui-container tui-container_fullwidth">
-    <p
-        class="tui-island__paragraph tui-text_body-xs tui-space_bottom-0 tui-space_top-10"
-        [class.tui-skeleton]="!uqj"
-        [class.tui-skeleton_short]="!uqj"
-        [class.tui-skeleton_text]="!uqj"
-    >
-        {{ uqj?.question?.category_obj?.full_name || 'No Category' | uppercase }}
-    </p>
-    <div class="tui-space_bottom-10 tui-space_top-2">
-        <div class="question-header">
-            <h1
-                class="tui-text_h3 tui-space_vertical-1"
+<div class="question">
+    <div class="question_content">
+        <div class="tui-container tui-container_fullwidth">
+            <p
+                class="tui-island__paragraph tui-text_body-xs tui-space_bottom-0 tui-space_top-10"
                 [class.tui-skeleton]="!uqj"
+                [class.tui-skeleton_short]="!uqj"
                 [class.tui-skeleton_text]="!uqj"
             >
-                {{ uqj?.question?.title ?? 'Question Title' }}
-            </h1>
-            <tui-badge
-                class="tui-space_left-4"
-                [class.tui-skeleton]="!uqj"
-                [status]="uqj.status | tuiStatus"
-                [value]="uqj.status"
-                *ngIf="uqj && uqj.status !== 'No Status' && uqj.status !== 'New'"
-            ></tui-badge>
-        </div>
-        <p
-            class="tui-space_top-2 tui-space_bottom-0"
-            [class.tui-skeleton]="!uqj"
-            [class.tui-skeleton_short]="!uqj"
-            [class.tui-skeleton_text]="!uqj"
-        >
-            {{ uqj?.question?.token_value || 'No' }}
-            &nbsp;Tokens Possible
-        </p>
-        <p
-            class="tui-space_vertical-0"
-            [class.tui-skeleton]="!uqj"
-            [class.tui-skeleton_short]="!uqj"
-            [class.tui-skeleton_text]="!uqj"
-        >
-            {{ (uqj?.question?.max_submission_allowed - uqj?.num_attempts) ?? 'Unlimited' }}
-            &nbsp;Attempts Remaining
-        </p>
-    </div>
-    <div class="tui-row tui-row_adaptive">
-        <div class="tui-col_xs-12 tui-col_md-8 tui-col_lg-8">
+                {{ uqj?.question?.category_obj?.full_name || 'No Category' | uppercase }}
+            </p>
+            <div class="tui-space_bottom-10 tui-space_top-2">
+                <div class="question-header">
+                    <h1
+                        class="tui-text_h3 tui-space_vertical-1"
+                        [class.tui-skeleton]="!uqj"
+                        [class.tui-skeleton_text]="!uqj"
+                    >
+                        {{ uqj?.question?.title ?? 'Question Title' }}
+                    </h1>
+                    <tui-badge
+                        class="tui-space_left-4"
+                        [class.tui-skeleton]="!uqj"
+                        [status]="uqj.status | tuiStatus"
+                        [value]="uqj.status"
+                        *ngIf="uqj && uqj.status !== 'No Status' && uqj.status !== 'New'"
+                    ></tui-badge>
+                </div>
+                <p
+                    class="tui-space_top-2 tui-space_bottom-0"
+                    [class.tui-skeleton]="!uqj"
+                    [class.tui-skeleton_short]="!uqj"
+                    [class.tui-skeleton_text]="!uqj"
+                >
+                    {{ uqj?.question?.token_value || 'No' }}
+                    &nbsp;Tokens Possible
+                </p>
+                <p
+                    class="tui-space_vertical-0"
+                    [class.tui-skeleton]="!uqj"
+                    [class.tui-skeleton_short]="!uqj"
+                    [class.tui-skeleton_text]="!uqj"
+                >
+                    {{ (uqj?.question?.max_submission_allowed - uqj?.num_attempts) ?? 'Unlimited' }}
+                    &nbsp;Attempts Remaining
+                </p>
+            </div>
             <div class="question-skeleton tui-skeleton" *ngIf="!uqj"></div>
             <tui-island *ngIf="renderedText">
                 <p class="tui-island__category">Question</p>
@@ -62,18 +62,18 @@
                 <app-parsons-view-snippet [uqj]="uqj"
                                           (successfulSubmissionEvent)="updateQuestionSubmissions($event)"></app-parsons-view-snippet>
             </ng-container>
-        </div>
-        <div class="tui-col_xs-12 tui-col_md-4 tui-col_lg-4">
             <div class="question-skeleton tui-skeleton" *ngIf="!uqj"></div>
-            <ng-container *ngIf="user?.is_teacher && uqj">
-                <app-variable-view
-                    [variables]="uqj.variables"
-                    [variableErrors]="uqj.variables_errors"
-                ></app-variable-view>
-            </ng-container>
-            <ng-container *ngIf="previousSubmissions">
-                <app-submission-snippet [previousSubmissions]="previousSubmissions"></app-submission-snippet>
-            </ng-container>
         </div>
     </div>
+    <app-sidebar sidebarId="questionSidebar" position="right" size="l">
+        <ng-container *ngIf="user?.is_teacher && uqj">
+            <app-variable-view
+                [variables]="uqj.variables"
+                [variableErrors]="uqj.variables_errors"
+            ></app-variable-view>
+        </ng-container>
+        <ng-container *ngIf="previousSubmissions">
+            <app-submission-snippet [previousSubmissions]="previousSubmissions"></app-submission-snippet>
+        </ng-container>
+    </app-sidebar>
 </div>

--- a/src/app/problems/problem-view/problem-view.component.scss
+++ b/src/app/problems/problem-view/problem-view.component.scss
@@ -1,9 +1,23 @@
-.question-header {
-    display: flex;
-    align-items: center;
-}
+@import "mixins";
 
-.question-skeleton {
-    height: 30rem;
-    width: 100%;
+.question {
+    display: flex;
+
+    @include screen-sm() {
+        flex-direction: column;
+    }
+
+    &_content {
+        flex: 1;
+    }
+
+    &-header {
+        display: flex;
+        align-items: center;
+    }
+
+    &-skeleton {
+        height: 30rem;
+        width: 100%;
+    }
 }

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.html
@@ -1,4 +1,4 @@
-<tui-island class="previous-submissions-island">
+<tui-island class="previous-submissions-island tui-space_vertical-6">
     <h2 class="tui-text_h6 tui-space_top-0 previous-submissions-island__title">My Past Submissions</h2>
     <ng-container *ngIf="previousSubmissions.length > 0 else noSubmissions">
         <tui-accordion [rounded]="false" class="tui-space_bottom-4">

--- a/src/app/problems/problem-view/variable-view/variable-view.component.html
+++ b/src/app/problems/problem-view/variable-view/variable-view.component.html
@@ -1,4 +1,4 @@
-<tui-island class="tui-space_bottom-6">
+<tui-island class="tui-space_top-6">
     <h2 class="tui-text_h6 tui-space_top-0">Generated Variables</h2>
     <ng-container *ngIf="generatedVariables.length !== 0; else elseBlock">
         <p class="tui-island__paragraph" *ngFor="let variable of generatedVariables">

--- a/src/app/problems/problems.module.ts
+++ b/src/app/problems/problems.module.ts
@@ -80,6 +80,7 @@ import {CodeEditorModule} from '@app/components/code-editor/code-editor.module';
 import {EditorModule} from '@app/components/editor/editor.module';
 import {TuiEditorSocketModule} from '@taiga-ui/addon-editor';
 import {TuiActiveZoneModule} from '@taiga-ui/cdk';
+import {SidebarModule} from '@app/components/sidebar/sidebar.module';
 
 @NgModule({
     declarations: [
@@ -113,6 +114,7 @@ import {TuiActiveZoneModule} from '@taiga-ui/cdk';
         PipesModule,
         ProblemsRoutingModule,
         ReactiveFormsModule,
+        SidebarModule,
         TabListViewSwitcherModule,
         TuiAccordionModule,
         TuiActiveZoneModule,

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -59,6 +59,7 @@
 
         @if($position == left) {
             border-bottom: 1px solid var(--tui-base-03);
+            margin-bottom: var(--tui-padding-l);
         }
 
         @if($position == right) {

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -37,10 +37,8 @@
     width: $width;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
     margin-bottom: -1.5rem;
-    min-height: calc(100vh - 8rem - 2px); // Window height - header + footer height - border widths
-    max-height: calc(100vh - 4rem - 1px); // Window height - header height - border width
+    height: calc(100vh - 4rem - 1px); // Window height - header - border width
     overflow: auto;
 
     @if($position == left) {
@@ -57,6 +55,7 @@
         max-height: unset;
         border: none;
         width: 100%;
+        height: auto;
 
         @if($position == left) {
             border-bottom: 1px solid var(--tui-base-03);
@@ -64,6 +63,7 @@
 
         @if($position == right) {
             border-top: 1px solid var(--tui-base-03);
+            margin-top: var(--tui-padding-l);
         }
     }
 }


### PR DESCRIPTION
## Description
 - Create sidebar component
   - Can be toggled to remove details from the view
   - Visually the same as previous sidebar usage besides toggle area underneath it
   - Customizable with size, position, spacing
   - Open/closed is remembered between pages
 - Test component
 - Update existing sidebars to use component
 - Add sidebar component to question page

## Types of changes
What types of changes does your code introduce?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue
Closes #498 

## Tests
Tested new component

## Screenshots (if appropriate):
https://user-images.githubusercontent.com/37320754/166587004-3709e3c9-d48a-4ba4-976d-747ea0e5110d.mp4


