### PR TITLE
Made the website name tile clickable 

### DIFF
--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -29,7 +29,7 @@
         <a class="tui-space_right-2" routerLink="" tuiLink>
             <img [src]="logoPath" alt="Logo">
         </a>
-        <span class="tui-text_h6">Canvas Gamification</span>
+        <span class="tui-text_h6 link" (click)="redirectHome()">Canvas Gamification</span>
     </div>
     <nav class="header-nav">
         <a class="tui-text_body-m" routerLink="homepage" tuiLink>Dashboard</a>

--- a/src/app/components/header/header.component.scss
+++ b/src/app/components/header/header.component.scss
@@ -133,3 +133,6 @@
     }
 }
 
+.link {
+    cursor: pointer;
+}

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -40,6 +40,10 @@ export class HeaderComponent {
         })
     }
 
+    redirectHome() : void {
+        this.router.navigate(['/'])
+    }
+
     setNightMode(value: boolean): void {
         // Temporarily disable night mode
         if (value) return

--- a/src/app/course/course.component.html
+++ b/src/app/course/course.component.html
@@ -16,7 +16,7 @@
         </a>
     </div>
     <tui-tabs-with-more #tabsComponent [class.tui-skeleton]="!course" [moreContent]="more" class="tui-space_bottom-4">
-        <button *tuiTab aria-label="Concepts" tuiTab>Concept Map</button>
+        <button *tuiTab aria-label="Concepts" tuiTab>Concepts</button>
         <!--        disable the question tabs for now. Should only be visible to admins -->
         <button *tuiTab aria-label="Questions" tuiTab disabled>Questions</button>
         <button *tuiTab aria-label="Events" tuiTab disabled>Events</button>

--- a/src/app/course/course.component.html
+++ b/src/app/course/course.component.html
@@ -16,7 +16,7 @@
         </a>
     </div>
     <tui-tabs-with-more #tabsComponent [class.tui-skeleton]="!course" [moreContent]="more" class="tui-space_bottom-4">
-        <button *tuiTab aria-label="Concepts" tuiTab>Concepts</button>
+        <button *tuiTab aria-label="Concepts" tuiTab>Concept Map</button>
         <!--        disable the question tabs for now. Should only be visible to admins -->
         <button *tuiTab aria-label="Questions" tuiTab disabled>Questions</button>
         <button *tuiTab aria-label="Events" tuiTab disabled>Events</button>


### PR DESCRIPTION
## Description

Changed the website tile so that you can click on the name and it redirects to the homepage 

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [x] Documentation is updated (if applicable).

## Issue

https://github.com/Hedgemon4/canvas-gamification-ui-COSOC447-directed-studies/issues/3

## Tests

No tests added or changed

## Screenshots (if appropriate):

![Website Tile Clickable](https://user-images.githubusercontent.com/83678885/193476633-eeb83ba0-4e2c-4f0d-b629-3bef01459d43.png)


