### PR TITLE
Hide quick links and fix event creation redirect

### DIFF
--- a/src/app/course/course-event-create/course-event-create-edit.component.ts
+++ b/src/app/course/course-event-create/course-event-create-edit.component.ts
@@ -57,7 +57,7 @@ export class CourseEventCreateEditComponent implements OnInit {
                     .show('The Event has been updated Successfully.', {
                         status: TuiNotification.Success
                     }).subscribe()
-                this.router.navigate(['course', this.courseId, 'event']).then()
+                this.router.navigate(['course', this.courseId, 'assignments-exams']).then()
             }, error => {
                 this.notificationsService
                     .show(error, {
@@ -70,7 +70,7 @@ export class CourseEventCreateEditComponent implements OnInit {
                     .show('The Event has been added Successfully.', {
                         status: TuiNotification.Success
                     })
-                this.router.navigate(['course', this.courseId, 'event']).then()
+                this.router.navigate(['course', this.courseId, 'assignments-exams']).then()
             }, error => {
                 this.notificationsService
                     .show(error, {

--- a/src/app/course/course-practice-page/course-practice-page.component.html
+++ b/src/app/course/course-practice-page/course-practice-page.component.html
@@ -56,60 +56,60 @@
 
     </div>
 
-    <h5 class="tui-text_h5 quick-links mt-10">Quick Links</h5>
+<!--    <h5 class="tui-text_h5 quick-links mt-10">Quick Links</h5>-->
 
-    <p class="tui-island__paragraph tui-text_body-xl tui-space_top-3">Select an
-        option to quickly navigate to a practice
-        question.</p>
+<!--    <p class="tui-island__paragraph tui-text_body-xl tui-space_top-3">Select an-->
+<!--        option to quickly navigate to a practice-->
+<!--        question.</p>-->
 
 
-    <div class="flex flex-wrap justify-center gap-8 tui-space_top-7">
-        <div
-            tuiHintPointer
-            tuiHint="Coming Soon..."
-            tuiHintDirection="top-middle"
-            class="tui-space_right-3 tui-space_bottom-3"
-        >
-            <button
-                tuiButton
-                type="button"
-                appearance="flat"
-                disabled="true"
-            >
-                Random Question
-            </button>
-        </div>
-        <div
-            tuiHintPointer
-            tuiHint="Coming Soon..."
-            tuiHintDirection="top-middle"
-            class="tui-space_right-3 tui-space_bottom-3"
-        >
-            <button
-                tuiButton
-                disabled="true"
-                type="button"
-                appearance="flat"
-                class="tui-space_right-3 tui-space_bottom-3"
-            >
-                Recommended Question
-            </button>
-        </div>
-        <div
-            tuiHintPointer
-            tuiHint="Coming Soon..."
-            tuiHintDirection="top-middle"
-            class="tui-space_right-3 tui-space_bottom-3"
-        >
-            <button
-                tuiButton
-                disabled="true"
-                type="button"
-                appearance="flat"
-                class="tui-space_right-3 tui-space_bottom-3"
-            >
-                Continue Practice
-            </button>
-        </div>
-    </div>
+<!--    <div class="flex flex-wrap justify-center gap-8 tui-space_top-7">-->
+<!--        <div-->
+<!--            tuiHintPointer-->
+<!--            tuiHint="Coming Soon..."-->
+<!--            tuiHintDirection="top-middle"-->
+<!--            class="tui-space_right-3 tui-space_bottom-3"-->
+<!--        >-->
+<!--            <button-->
+<!--                tuiButton-->
+<!--                type="button"-->
+<!--                appearance="flat"-->
+<!--                disabled="true"-->
+<!--            >-->
+<!--                Random Question-->
+<!--            </button>-->
+<!--        </div>-->
+<!--        <div-->
+<!--            tuiHintPointer-->
+<!--            tuiHint="Coming Soon..."-->
+<!--            tuiHintDirection="top-middle"-->
+<!--            class="tui-space_right-3 tui-space_bottom-3"-->
+<!--        >-->
+<!--            <button-->
+<!--                tuiButton-->
+<!--                disabled="true"-->
+<!--                type="button"-->
+<!--                appearance="flat"-->
+<!--                class="tui-space_right-3 tui-space_bottom-3"-->
+<!--            >-->
+<!--                Recommended Question-->
+<!--            </button>-->
+<!--        </div>-->
+<!--        <div-->
+<!--            tuiHintPointer-->
+<!--            tuiHint="Coming Soon..."-->
+<!--            tuiHintDirection="top-middle"-->
+<!--            class="tui-space_right-3 tui-space_bottom-3"-->
+<!--        >-->
+<!--            <button-->
+<!--                tuiButton-->
+<!--                disabled="true"-->
+<!--                type="button"-->
+<!--                appearance="flat"-->
+<!--                class="tui-space_right-3 tui-space_bottom-3"-->
+<!--            >-->
+<!--                Continue Practice-->
+<!--            </button>-->
+<!--        </div>-->
+<!--    </div>-->
 </section>


### PR DESCRIPTION
## Description

Hid the quick links on the course practice page and fixed event creation redirect

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

https://github.com/canvas-gamification/canvas-gamification-ui/issues/574

https://github.com/canvas-gamification/canvas-gamification-ui/issues/573

## Tests

No tests changed

## Images

![image](https://user-images.githubusercontent.com/83678885/210411379-768fb104-27ee-4304-8ba5-b2cfb050acbb.png)

