### PR TITLE
Added breadcrumbs to leaderboard page

### DIFF
--- a/src/app/course/course-routing.module.ts
+++ b/src/app/course/course-routing.module.ts
@@ -548,16 +548,24 @@ const routes: Routes = [
                     }]
                 }
             },
+            {
+                path: 'leaderboard',
+                component: LeaderBoardPageComponent,
+                data: {
+                    breadCrumbs: [{
+                        caption: `Homepage`,
+                        routerLink: '/course/:courseId/homepage'
+                    }, {
+                        caption: `Leaderboard`,
+                        routerLink: '/course/:courseId/leaderboard'
+                    },]
+                }
+            },
         ]
     },
     {
         path: ':courseId/practice/category/:categoryId',
         component: PracticeProblemComponent,
-        canActivate: [AuthGuard]
-    },
-    {
-        path: ':courseId/leaderboard',
-        component: LeaderBoardPageComponent,
         canActivate: [AuthGuard]
     }]
 

--- a/src/app/course/leader-board-page/leader-board-page.component.html
+++ b/src/app/course/leader-board-page/leader-board-page.component.html
@@ -1,3 +1,4 @@
+<div class="line"></div>
 <div class="flex flex-col md:flex-row">
     <app-sidebar sidebarId="leaderBoardPageSide">
         <a

--- a/src/app/course/leader-board-page/leader-board-page.component.scss
+++ b/src/app/course/leader-board-page/leader-board-page.component.scss
@@ -13,6 +13,5 @@
 }
 
 .line {
-    height: 1px;
-    background:  var(--tui-base-03);
+    border-top: 1px solid var(--tui-base-03);
 }

--- a/src/app/course/leader-board-page/leader-board-page.component.scss
+++ b/src/app/course/leader-board-page/leader-board-page.component.scss
@@ -11,3 +11,8 @@
 .clicked {
     background-color: var(--tui-base-02);
 }
+
+.line {
+    height: 1px;
+    background:  var(--tui-base-03);
+}

--- a/src/app/course/leader-board-page/leader-board-page.component.ts
+++ b/src/app/course/leader-board-page/leader-board-page.component.ts
@@ -23,7 +23,7 @@ export class LeaderBoardPageComponent implements OnInit {
     }
 
     ngOnInit(): void {
-        this.courseId = this.route.snapshot.params.courseId
+        this.courseId = this.route.snapshot.parent.params.courseId
         this.courseService.getCourse(this.courseId).subscribe(course => {
             this.course = course
             this.events = course.events.filter(event => event.type === 'CHALLENGE')


### PR DESCRIPTION
## Description

Moved the leaderboard into course navigation, added breadcrumbs and added a top line to separate the course header from the leaderboard and sidebar display. 

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [x] Every file touched has tests that cover all the funcitonality with green coverage
- [x] Documentation is updated (if applicable).

## Issue

https://github.com/canvas-gamification/canvas-gamification-ui/issues/626

## Tests

No tests changed 

## Screenshots (if appropriate):

Old Leaderboard:
![image](https://user-images.githubusercontent.com/83678885/218198076-3f5f3fc4-f67d-45a7-bae3-16af89f9ba92.png)

New Leaderboard:
![image](https://user-images.githubusercontent.com/83678885/218197954-a2fd5b4e-1e85-4f7b-bd96-4846e817b2d2.png)
