### PR TITLE
Fix the display order of event questions

### DIFF
--- a/src/app/course/_utils/orderUQJs.ts
+++ b/src/app/course/_utils/orderUQJs.ts
@@ -1,7 +1,7 @@
 import {UQJ} from "@app/_models"
 
 
-export const orderQuestions = (uqjs: UQJ[]): UQJ[] =>  {
+export const orderUQJs = (uqjs: UQJ[]): UQJ[] =>  {
     const numsArr: UQJ[] = []
     const stringsArr: UQJ[] = []
 

--- a/src/app/course/_utils/orderUQJs.ts
+++ b/src/app/course/_utils/orderUQJs.ts
@@ -1,0 +1,30 @@
+import {UQJ} from "@app/_models"
+
+
+export const orderQuestions = (uqjs: UQJ[]): UQJ[] =>  {
+    const numsArr: UQJ[] = []
+    const stringsArr: UQJ[] = []
+
+    for (const uqj of uqjs) {
+        if (containsNumbers(uqj.question.title))
+            numsArr.push(uqj)
+        else
+            stringsArr.push(uqj)
+    }
+
+    numsArr.sort((a, b) => extractNumberFromString(a.question.title)
+        - extractNumberFromString(b.question.title))
+
+    stringsArr.sort((a, b) =>
+        a.question.title.localeCompare(b.question.title))
+
+    return numsArr.concat(stringsArr)
+}
+
+const containsNumbers = (str): boolean => {
+    return str.match(/\d/) !== null
+}
+
+const extractNumberFromString = (str): number => {
+    return +str.match(/(\d+)/)[0]
+}

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -17,6 +17,7 @@ import {
 } from "@taiga-ui/core"
 import {startCase} from "lodash"
 import {PolymorpheusContent} from "@tinkoff/ng-polymorpheus"
+import {orderQuestions} from "@app/course/_utils/orderUQJs"
 
 @Component({
     selector: 'app-course-question-snippet',
@@ -59,7 +60,7 @@ export class CourseQuestionSnippetComponent implements OnInit {
                     }).subscribe(result => {
                         this.event = result.event
                         this.uqjs = result.uqjs.results
-                        this.orderQuestions()
+                        this.uqjs = orderQuestions(this.uqjs)
                     })
                 } else {
                     this.router.navigate(['course/view', this.courseId]).then()
@@ -73,34 +74,6 @@ export class CourseQuestionSnippetComponent implements OnInit {
         this.courseId = +this.route.snapshot.parent.paramMap.get('courseId') || null
         this.eventId = +this.route.snapshot.paramMap.get('eventId') || null
         this.init()
-    }
-
-    orderQuestions(): void {
-        const numsArr: UQJ[] = []
-        const stringsArr: UQJ[] = []
-
-        for (const uqj of this.uqjs) {
-            if (this.containsNumbers(uqj.question.title))
-                numsArr.push(uqj)
-            else
-                stringsArr.push(uqj)
-        }
-
-        numsArr.sort((a, b) => this.scrapeNumberFromString(a.question.title)
-            - this.scrapeNumberFromString(b.question.title))
-
-        stringsArr.sort((a, b) =>
-            a.question.title.localeCompare(b.question.title))
-
-        this.uqjs = numsArr.concat(stringsArr)
-    }
-
-    containsNumbers(str): boolean {
-        return str.match(/\d/) !== null
-    }
-
-    scrapeNumberFromString(str): number {
-        return +str.match(/(\d+)/)[0]
     }
 
     /**

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -17,7 +17,7 @@ import {
 } from "@taiga-ui/core"
 import {startCase} from "lodash"
 import {PolymorpheusContent} from "@tinkoff/ng-polymorpheus"
-import {orderQuestions} from "@app/course/_utils/orderUQJs"
+import {orderUQJs} from "@app/course/_utils/orderUQJs"
 
 @Component({
     selector: 'app-course-question-snippet',
@@ -60,7 +60,7 @@ export class CourseQuestionSnippetComponent implements OnInit {
                     }).subscribe(result => {
                         this.event = result.event
                         this.uqjs = result.uqjs.results
-                        this.uqjs = orderQuestions(this.uqjs)
+                        this.uqjs = orderUQJs(this.uqjs)
                     })
                 } else {
                     this.router.navigate(['course/view', this.courseId]).then()

--- a/src/app/course/course-question-snippet/course-question-snippet.component.ts
+++ b/src/app/course/course-question-snippet/course-question-snippet.component.ts
@@ -48,11 +48,6 @@ export class CourseQuestionSnippetComponent implements OnInit {
         this.authenticationService.currentUser.subscribe(user => this.user = user)
     }
 
-    orderQuestions(): void {
-        this.uqjs.sort((a, b) =>
-            a.question.title.localeCompare(b.question.title))
-    }
-
     init() {
         this.courseService.getCourse(this.courseId).subscribe(course => this.course = course)
         if (this.eventId && this.courseId) { // if this snippet is an event-view
@@ -78,6 +73,34 @@ export class CourseQuestionSnippetComponent implements OnInit {
         this.courseId = +this.route.snapshot.parent.paramMap.get('courseId') || null
         this.eventId = +this.route.snapshot.paramMap.get('eventId') || null
         this.init()
+    }
+
+    orderQuestions(): void {
+        const numsArr: UQJ[] = []
+        const stringsArr: UQJ[] = []
+
+        for (const uqj of this.uqjs) {
+            if (this.containsNumbers(uqj.question.title))
+                numsArr.push(uqj)
+            else
+                stringsArr.push(uqj)
+        }
+
+        numsArr.sort((a, b) => this.scrapeNumberFromString(a.question.title)
+            - this.scrapeNumberFromString(b.question.title))
+
+        stringsArr.sort((a, b) =>
+            a.question.title.localeCompare(b.question.title))
+
+        this.uqjs = numsArr.concat(stringsArr)
+    }
+
+    containsNumbers(str): boolean {
+        return str.match(/\d/) !== null
+    }
+
+    scrapeNumberFromString(str): number {
+        return +str.match(/(\d+)/)[0]
     }
 
     /**
@@ -195,8 +218,8 @@ export class CourseQuestionSnippetComponent implements OnInit {
             }).subscribe()
         } else {
             this.router.navigate(
-                ['../' , this.eventId, 'problem', 'create', link]
-                ,{relativeTo: this.route}
+                ['../', this.eventId, 'problem', 'create', link]
+                , {relativeTo: this.route}
             ).then()
         }
     }


### PR DESCRIPTION
## Description

Question titles that include numbers will be on the top of the page, and others will be on the bottom of the page.
The code now allows the question with the title 2 ordered before 10.

## Types of changes

What types of changes does your code introduce?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (only improve the code quality no change in functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [ ] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

closes #664 

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
