### PR TITLE
add loading skeleton to import assessment

### DIFF
--- a/src/app/course/event/course-events-snippet/course-events-snippet.component.html
+++ b/src/app/course/event/course-events-snippet/course-events-snippet.component.html
@@ -201,7 +201,6 @@
                 </ng-template>
             </tui-accordion-item>
         </tui-accordion>
-
     </ng-container>
     <ng-template #skeletonTemplate>
         <div class="functionBar">

--- a/src/app/course/event/course-events-snippet/course-events-snippet.component.html
+++ b/src/app/course/event/course-events-snippet/course-events-snippet.component.html
@@ -52,7 +52,7 @@
                 #importDialog
                 let-observer
             >
-                <ng-container *ngIf="courseEvents">
+                <ng-container *ngIf="courseEvents else skeletonTemplate">
                     <div class="tui-space_top-8 space-y-3">
                         <a
                             (click)="observer.complete()"
@@ -100,6 +100,25 @@
                 >
                     Close
                 </button>
+            </ng-template>
+            <ng-template
+                #skeletonTemplate
+            >
+                <ng-container>
+                    <div class="tui-space_top-8 space-y-3">
+                        <a
+                            size="s"
+                            textAlign="center"
+                            tuiIsland
+                            class="tui-skeleton"
+                        >
+                            <figure class="tui-island__figure">
+                                <tui-svg src="tuiIconPlusLarge"></tui-svg>
+                            </figure>
+                            <h2 class="tui-island__title">Create New Assessment</h2>
+                        </a>
+                    </div>
+                </ng-container>
             </ng-template>
         </div>
         <tui-accordion [closeOthers]="false">
@@ -182,6 +201,7 @@
                 </ng-template>
             </tui-accordion-item>
         </tui-accordion>
+
     </ng-container>
     <ng-template #skeletonTemplate>
         <div class="functionBar">


### PR DESCRIPTION
## Description

Describe your changes in detail
Added a loading skeleton to the event list in the import to assessment pop up. I decided on only one skeleton bar because that is the minimum that will show up on the loaded page, therefore it will only grow larger and never smaller.

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/canvas-gamification/canvas-gamification-ui/issues/692

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://github.com/canvas-gamification/canvas-gamification-ui/assets/79422004/64de4940-c1dd-4760-b5c2-208e36b7cde9)
![image](https://github.com/canvas-gamification/canvas-gamification-ui/assets/79422004/24ed3be0-c563-47eb-8d9a-87f8eb421c24)
