### PR TITLE
removed file preview for hidden files in the submission view

### DIFF
--- a/src/app/problems/problem-view/problem-view.component.html
+++ b/src/app/problems/problem-view/problem-view.component.html
@@ -76,6 +76,7 @@
         <ng-container *ngIf="!!uqj">
             <app-submission-snippet
                 [questionId]="uqj.question.id"
+                [inputFiles]="uqj.input_files"
                 (reloadRequestSubscriberEvent)="reloadRequestSubscriber = $event">
             </app-submission-snippet>
         </ng-container>

--- a/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
+++ b/src/app/problems/problem-view/submission-snippet/submission-snippet.component.ts
@@ -16,6 +16,7 @@ import {SubmissionViewComponent} from '@app/problems/submission-view/submission-
 import {SubmissionService} from "@app/problems/_services/submission.service"
 import {map} from "rxjs/operators"
 import {Observable, Subscriber} from "rxjs"
+import {InputFiles} from "@app/_models"
 
 @Component({
     selector: 'app-submission-snippet',
@@ -25,6 +26,7 @@ import {Observable, Subscriber} from "rxjs"
 export class SubmissionSnippetComponent implements OnChanges, OnInit {
 
     @Input() questionId: number
+    @Input() inputFiles: InputFiles
     @Output() readonly reloadRequestSubscriberEvent = new EventEmitter<Subscriber<never>>()
 
     reloadRequestObservable: Observable<never>
@@ -77,7 +79,7 @@ export class SubmissionSnippetComponent implements OnChanges, OnInit {
             new PolymorpheusComponent(SubmissionViewComponent, this.injector),
             {
                 size: 'l',
-                data: submission,
+                data: {submission: submission, hiddenFileNames: this.getHiddenFiles()},
                 closeable: false,
                 label: `Submission ${index}`
             }
@@ -94,5 +96,14 @@ export class SubmissionSnippetComponent implements OnChanges, OnInit {
     submissionAppropriateSize(submission: QuestionSubmission): boolean {
         return submission.safeAnswer.toString().length < 500 &&
             submission.safeAnswer.toString().indexOf('image') === -1
+    }
+
+    getHiddenFiles(): string[] {
+        const files = this.inputFiles.filter(val => val.hidden)
+        const names:string[] = []
+        for(let x = 0; x < files.length; x++){
+            names[x] = files[x].name
+        }
+        return names
     }
 }

--- a/src/app/problems/submission-view/submission-view.component.ts
+++ b/src/app/problems/submission-view/submission-view.component.ts
@@ -18,13 +18,16 @@ export class SubmissionViewComponent implements OnInit {
         private submissionService: SubmissionService,
         private route: ActivatedRoute,
         @Inject(POLYMORPHEUS_CONTEXT)
-        private readonly context: TuiDialogContext<QuestionSubmission>,
+        private readonly context: TuiDialogContext<null, {
+            submission: QuestionSubmission,
+            hiddenFileNames: string[],
+        }>,
         private changeDetector: ChangeDetectorRef
     ) {
     }
 
     ngOnInit(): void {
-        this.submission = this.context.data
+        this.submission = this.context.data.submission
         this.answerFiles =
             Object.entries(this.submission.answer_files)
                 .reduce((prev, [key, value]) => {
@@ -33,6 +36,9 @@ export class SubmissionViewComponent implements OnInit {
                         code: value
                     }]
                 }, [])
+        this.context.data.hiddenFileNames.forEach(name => {
+            this.answerFiles = this.answerFiles.filter(value => value.name !== name)
+        })
         this.changeDetector.detectChanges()
     }
 


### PR DESCRIPTION
## Description

Describe your changes in detail

carried file name information from uqj forward to the submission view so the displayed files could be filtered against the list of hidden files

## Types of changes

What types of changes does your code introduce?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (only improve the code quality no change in functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] Issue has been created
- [x] Every file touched is linted
- [ ] Every file touched has tests that cover all the funcitonality with green coverage
- [ ] Documentation is updated (if applicable).

## Issue

Please link the issue here.
https://github.com/canvas-gamification/canvas-gamification-ui/issues/747

## Tests

Please describe in detail what tests you added or changed.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/372dace7-6df1-474b-ac97-2643bafddb2f)
