### PR TITLE
ci: run on Node 24 and update retired artifact actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,13 +7,13 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
-                node: [ 16.10.0 ]
+                node: [ '24.16.0' ]
         runs-on: ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
             -   name: Set Up Node
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v4
                 with:
                     node-version: ${{ matrix.node }}
                     cache: 'npm'
@@ -26,13 +26,13 @@ jobs:
         strategy:
             matrix:
                 os: [ ubuntu-latest, windows-latest, macos-latest ]
-                node: [ 16.10.0 ]
+                node: [ '24.16.0' ]
         runs-on: ${{ matrix.os }}
         steps:
             -   name: Checkout
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
             -   name: Set Up Node
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v4
                 with:
                     node-version: ${{ matrix.node }}
                     cache: 'npm'
@@ -46,8 +46,8 @@ jobs:
             #                    npm run e2e:ci:init
             #                    npm run e2e:ci
             -   name: Archive code coverage result
-                if: success() && startsWith(matrix.os, 'ubuntu') && startsWith(matrix.node, '16')
-                uses: actions/upload-artifact@v1
+                if: success() && startsWith(matrix.os, 'ubuntu') && startsWith(matrix.node, '24')
+                uses: actions/upload-artifact@v4
                 with:
                     name: deploy_coverage
                     path: coverage
@@ -59,11 +59,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout
-                uses: actions/checkout@v1
-            -   name: Node 16.x
-                uses: actions/setup-node@v1
+                uses: actions/checkout@v4
+            -   name: Set Up Node
+                uses: actions/setup-node@v4
                 with:
-                    node-version: '16.x'
+                    node-version-file: '.nvmrc'
                     cache: 'npm'
             -   name: Install dependencies
                 run: npm ci
@@ -73,7 +73,7 @@ jobs:
                 run: npm run copy
             -   name: Archive build
                 if: success()
-                uses: actions/upload-artifact@v1
+                uses: actions/upload-artifact@v4
                 with:
                     name: deploy_dist
                     path: dist
@@ -83,15 +83,19 @@ jobs:
         if: github.ref == 'refs/heads/master'
         steps:
             -   name: Checkout
-                uses: actions/checkout@v1
+                uses: actions/checkout@v4
+            #   v1 unpacked into a directory named after the artifact; v4 unpacks into
+            #   `path`, so it is set explicitly to keep the FOLDER paths below unchanged.
             -   name: Download build
-                uses: actions/download-artifact@v1
+                uses: actions/download-artifact@v4
                 with:
                     name: deploy_dist
+                    path: deploy_dist
             -   name: Download coverage
-                uses: actions/download-artifact@v1
+                uses: actions/download-artifact@v4
                 with:
                     name: deploy_coverage
+                    path: deploy_coverage
             -   name: Deploy Code to GitHub Pages
                 uses: JamesIves/github-pages-deploy-action@releases/v3
                 with:


### PR DESCRIPTION
Fixes CI on `modernize-deps`. Based on that branch, not `master` — `master` is still on Angular 13 and needs Node 16, so pointing this at `master` would break it.

## Why CI is currently red

Two independent blockers, both from the last run on this branch ([30016553994](https://github.com/canvas-gamification/canvas-gamification-ui/actions/runs/30016553994)):

**1. Node 16 pins.** The dep modernization bumped Angular to 22, which won't start on Node 16:

```
Node.js version v16.10.0 detected.
The Angular CLI requires a minimum Node.js version of v22.22.3 or v24.15.0 or v26.0.0.
```

`.nvmrc` (→ `v24.16.0`) and `engines.node` (→ `>= 20.19.0`) were updated on this branch, but `build.yml` was missed. Lint and Build fail.

**2. Retired artifact actions.** The Test job never ran a single step — it died during "Set up job":

```
This request has been automatically failed because it uses a deprecated version
of `actions/upload-artifact: v1`.
```

`upload-artifact` v1/v2 [stopped working on 2024-06-30](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/). Unrelated to the dep upgrade — this would fail on `master` too.

## Changes

- Node matrices → `24.16.0`; Build job reads `node-version-file: '.nvmrc'` so there's one source of truth
- `upload-artifact` / `download-artifact` / `checkout` / `setup-node` → v4

Two details worth a look during review:

- The coverage upload is guarded on `startsWith(matrix.node, '16')`. Left stale it silently never uploads, and the `deploy` job's "Download coverage" step then fails — so it moves to `'24'` in lockstep with the matrix.
- `download-artifact@v1` unpacked into a directory named after the artifact; v4 unpacks into `path`. `path` is now set explicitly so the existing `FOLDER: deploy_dist/canvas-gamification-ui` still resolves.

Incidental fix: `cache: 'npm'` now actually caches. It was an unrecognized input on `setup-node@v1` (`Unexpected input(s) 'cache'`) and was being ignored.

## Verified

Locally on Node 24.16.0:

- `npm run lint` — passes, 0 errors (284 pre-existing `max-len`-style warnings, unchanged)
- `ng build` — succeeds; output layout is unchanged (flat `index.html` + hashed bundles + `assets/`), so `npm run generate-output` still drops straight into the Django backend's `static/angular`, and `npm run build:ci` + `npm run copy` still produce what the gh-pages deploy expects
- Workflow YAML parses; no `@v1` or Node 16 references remain

Not verified locally: `npm run test:ci` (needs a Chrome binary for `ChromeHeadlessCI`) and the `deploy` job, which only runs on `master`.

## Not included

`JamesIves/github-pages-deploy-action@releases/v3` in the `deploy` job is similarly ancient and probably wants a bump, but v4 renames all its inputs and that job can't run until this lands on `master`. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)